### PR TITLE
Update codeql-analysis.yml to be current

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,3 +44,9 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+      
+    - name: Upload Output
+      uses: actions/upload-artifact@v3
+      with:
+        path: /**/*.sarif
+        

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,5 +48,6 @@ jobs:
     - name: Upload Output
       uses: actions/upload-artifact@v3
       with:
+        name: ${{ matrix.language }} SARIF
         path: /**/*.sarif
         

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
         
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       # Get full history for spotless ratchetFrom
       with:
         fetch-depth: 0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
-  schedule:
-    - cron: '32 14 * * 0'
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,5 +49,5 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.language }} SARIF
-        path: /home/runner/work/BenchmarkJava/results/${{ matrix.language }}.sarif"
+        path: ${{ runner.workspace }}/results/*.sarif
         

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,10 +31,10 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        queries: security-extended, security-experimental, security-and-quality
 
     #- name: Autobuild
     #  uses: github/codeql-action/autobuild@v1
@@ -43,4 +43,4 @@ jobs:
       run: mvn -DskipTests=true install
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,5 +49,5 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.language }} SARIF
-        path: /**/*.sarif
+        path: /home/runner/work/BenchmarkJava/results/${{ matrix.language }}.sarif"
         

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,8 @@
 name: "CodeQL"
 
+env: 
+  CODEQL_EXTRACTOR_JAVA_RUN_ANNOTATION_PROCESSORS: true
+
 on:
   push:
     branches: [ master ]
@@ -16,7 +19,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
+    
     strategy:
       fail-fast: false
       matrix:
@@ -35,9 +38,6 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         queries: security-extended, security-experimental, security-and-quality
-
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
       
     - name: Build with Maven
       run: mvn -DskipTests=true install


### PR DESCRIPTION
This changeset alters the CodeQL analysis Action to run an expanded ruleset, leverages the "free for OSS" nature to produce an uploaded resultfile that can be included with the BenchmarkJava suite, removes the scheduled runs and allows manual triggers instead, and updates all actions to their latest versions. 